### PR TITLE
Fix import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![GitHub Release](https://img.shields.io/github/v/release/helloreindev/hoshii?include_prereleases)](https://github.com/helloreindev/hoshii/releases/latest)
 [![NPM](https://img.shields.io/npm/v/hoshii?color=green)](https://npmjs.com/package/hoshii)
 
-- Note: **This library is still in prototype version. Bugs are expected.**
-
 **Hoshii** is a NodeJS [Guilded](https://guilded.gg) library.
 
 - **Documentation:** [hoshii.js.org](https://hoshii.js.org)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,6 +40,6 @@ export * as Endpoints from "./rest/Endpoints";
 export * from "./rest/RequestHandler";
 export * from "./gateway/GatewayEventHandler";
 export * from "./gateway/GatewayHandler";
-export * from "./gateway/Websocket";
+export * from "./gateway/WebSocket";
 
 export const VERSION = pkgJSON.version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hoshii",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hoshii",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoshii",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "A NodeJS Guilded Library",
   "main": "src/lib/index.js",
   "engines": {


### PR DESCRIPTION
This PR fixes an issue where Node v19+ could not locate the exact module path. This also marks the v0.1.0 stable release.